### PR TITLE
feat: support LaTeX formulae via standard syntax or math code block

### DIFF
--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -10,3 +10,29 @@ This is not an inline formula:
 
 $$x = a_0 + \frac{1}{a_1 + \frac{1}{a_2 + \frac{1}{a_3 + a_4}}}$$  
 $$\forall x \in X, \quad \exists y \leq \epsilon$$
+
+As of Hugo v0.122.0, you may author LaTeX formulae using the standard syntax directly in Markdown
+
+````markdown
+The probability of getting \(k\) heads when flipping \(n\) coins is:
+\[
+\tag*{(1)} P(E) = {n \choose k} p^k (1-p)^{n-k}
+\]
+````
+
+For details, please have a look at the section [Mathematics in Markdown ](https://gohugo.io/content-management/mathematics/) of the official hugo documentation.
+
+As an alternative to the standard syntax used above, formulae can also be authored using a [GLFM math block](https://docs.gitlab.com/ee/user/markdown.html#math):
+
+````markdown
+The probability of getting \(k\) heads when flipping \(n\) coins is:
+```math
+\tag*{(1)} P(E) = {n \choose k} p^k (1-p)^{n-k}
+```
+````
+Both standard syntax and `math` block render to the same formula:
+
+The probability of getting \(k\) heads when flipping \(n\) coins is:
+```math
+\tag*{(1)}  P(E) = {n \choose k} p^k (1-p)^{n-k}
+```

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -24,3 +24,15 @@ title = 'Test site for mod-katex'
   [[module.imports.mounts]]
     source = "assets/js/modules/katex/katex-autoload.js"
     target = "static/js/katex-autoload.js"
+  [[module.imports.mounts]]
+    source = 'layouts'
+    target = 'layouts'
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.extensions]
+      [markup.goldmark.extensions.passthrough]
+        enable = true
+        [markup.goldmark.extensions.passthrough.delimiters]
+          block = [['\[', '\]'], ['$$', '$$']]
+          inline = [['\(', '\)']]

--- a/layouts/_default/_markup/render-codeblock-math.html
+++ b/layouts/_default/_markup/render-codeblock-math.html
@@ -1,0 +1,3 @@
+<div class="math">$$
+{{ .Inner | safeHTML -}}
+$$</div>{{ "" -}}


### PR DESCRIPTION
This PR improves the module in two ways:
* it adds a `math` code block that can be used to show formulae
* it demonstrates how to use LaTeX formulae in Markdown via standard syntax 